### PR TITLE
[CLNP-6518] fix: crash on iOS when using New Architecture

### DIFF
--- a/ios/RNSendbirdCalls.m
+++ b/ios/RNSendbirdCalls.m
@@ -55,7 +55,7 @@ RCT_EXTERN_METHOD(removeDirectCallSound
                   : (NSString *)type)
 
 RCT_EXTERN_METHOD(setDirectCallDialingSoundOnWhenSilentOrVibrateMode
-                  : (BOOL *)enabled)
+                  : (nonnull NSNumber *)enabled)
 
 RCT_EXTERN_METHOD(initialize
                   : (NSString *)appId)
@@ -84,7 +84,7 @@ RCT_EXTERN_METHOD(deauthenticate
 
 RCT_EXTERN_METHOD(registerPushToken
                   : (NSString *)token
-                  : (BOOL *)unique
+                  : (nonnull NSNumber *)unique
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject)
 
@@ -95,7 +95,7 @@ RCT_EXTERN_METHOD(unregisterPushToken
 
 RCT_EXTERN_METHOD(registerVoIPPushToken
                   : (NSString *)token
-                  : (BOOL *)unique
+                  : (nonnull NSNumber *)unique
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject)
 
@@ -106,7 +106,7 @@ RCT_EXTERN_METHOD(unregisterVoIPPushToken
 
 RCT_EXTERN_METHOD(dial
                   : (NSString *)calleeId
-                  : (BOOL *)isVideoCall
+                  : (nonnull NSNumber *)isVideoCall
                   : (NSDictionary *)options
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject)
@@ -130,7 +130,7 @@ RCT_EXTERN_METHOD(createRoom
 RCT_EXTERN_METHOD(accept
                   : (NSString *)callId
                   : (NSDictionary *)options
-                  : (BOOL *)holdActiveCall
+                  : (nonnull NSNumber *)holdActiveCall
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject)
 
@@ -141,11 +141,11 @@ RCT_EXTERN_METHOD(end
 
 RCT_EXTERN_METHOD(updateLocalVideoView
                   : (NSString *)callId
-                  : (NSNumber *)videoViewId)
+                  : (nonnull NSNumber *)videoViewId)
 
 RCT_EXTERN_METHOD(updateRemoteVideoView
                   : (NSString *)callId
-                  : (NSNumber *)videoViewId)
+                  : (nonnull NSNumber *)videoViewId)
 
 // MARK: - SendbirdCalls: GroupCall
 RCT_EXTERN_METHOD(enter

--- a/ios/RNSendbirdCalls.swift
+++ b/ios/RNSendbirdCalls.swift
@@ -35,7 +35,7 @@ class RNSendbirdCalls: RCTEventEmitter {
         module = CallsModule()
     }
     
-    @objc func handleRemoteNotificationData(data: [AnyHashable: Any]) {
+    @objc func handleRemoteNotificationData(_ data: [AnyHashable: Any]) {
         SendBirdCall.application(UIApplication.shared, didReceiveRemoteNotification: data)
     }
     
@@ -80,8 +80,8 @@ extension RNSendbirdCalls {
         module.queryNext(queryKey, type, Promise(resolve,reject))
     }
     
-    @objc func queryRelease(_ querKey: String) {
-        module.queryRelease(querKey)
+    @objc func queryRelease(_ queryKey: String) {
+        module.queryRelease(queryKey)
     }
 }
 
@@ -99,12 +99,13 @@ extension RNSendbirdCalls {
         module.removeDirectCallSound(type)
     }
     
-    @objc func setDirectCallDialingSoundOnWhenSilentOrVibrateMode(_ enabled: Bool) {
-        module.setDirectCallDialingSoundOnWhenSilentOrVibrateMode(enabled)
+    @objc func setDirectCallDialingSoundOnWhenSilentOrVibrateMode(_ enabled: NSNumber) {
+        module.setDirectCallDialingSoundOnWhenSilentOrVibrateMode(enabled.boolValue)
     }
     
-    @objc func initialize(_ appId: String) -> Bool {
-        return module.initialize(appId)
+    @objc func initialize(_ appId: String) -> NSNumber {
+        let result = module.initialize(appId)
+        return NSNumber(value: result)
     }
     
     @objc func getCurrentUser(_ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
@@ -127,24 +128,24 @@ extension RNSendbirdCalls {
         module.deauthenticate(Promise(resolve, reject))
     }
     
-    @objc func registerPushToken(_ token: String, _ unique: Bool, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
-        module.registerPushToken(token, unique, Promise(resolve, reject))
+    @objc func registerPushToken(_ token: String, _ unique: NSNumber, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.registerPushToken(token, unique.boolValue, Promise(resolve, reject))
     }
     
     @objc func unregisterPushToken(_ token: String, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
         module.unregisterPushToken(token, Promise(resolve, reject))
     }
     
-    @objc func registerVoIPPushToken(_ token: String, _ unique: Bool, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
-        module.registerVoIPPushToken(token, unique, Promise(resolve, reject))
+    @objc func registerVoIPPushToken(_ token: String, _ unique: NSNumber, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.registerVoIPPushToken(token, unique.boolValue, Promise(resolve, reject))
     }
     
     @objc func unregisterVoIPPushToken(_ token: String, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
         module.unregisterVoIPPushToken(token, Promise(resolve, reject))
     }
     
-    @objc func dial(_ calleeId: String, _ isVideoCall: Bool, _ options: [String: Any], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
-        module.dial(calleeId, isVideoCall, options, Promise(resolve, reject))
+    @objc func dial(_ calleeId: String, _ isVideoCall: NSNumber, _ options: [String: Any], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.dial(calleeId, isVideoCall.boolValue, options, Promise(resolve, reject))
     }
     
     @objc func fetchRoomById(_ roomId: String, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
@@ -162,8 +163,8 @@ extension RNSendbirdCalls {
 
 // MARK: DirectCall
 extension RNSendbirdCalls {
-    @objc func accept(_ callId: String, _ options: [String: Any], _ holdActiveCall: Bool, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
-        module.accept(callId, options, holdActiveCall, Promise(resolve, reject))
+    @objc func accept(_ callId: String, _ options: [String: Any], _ holdActiveCall: NSNumber, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.accept(callId, options, holdActiveCall.boolValue, Promise(resolve, reject))
     }
     
     @objc func end(_ callId: String, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {

--- a/sample/ios/Podfile
+++ b/sample/ios/Podfile
@@ -37,7 +37,7 @@ target 'SendbirdCallsRNSample' do
     :app_path => "#{Pod::Config.instance.installation_root}/..",
 
     # Temporary workaround: A SIGABRT occurs during iOS execution because the new architecture is not yet stabilized.
-    :new_arch_enabled => false
+    :new_arch_enabled => true
   )
 
   post_install do |installer|
@@ -46,7 +46,7 @@ target 'SendbirdCallsRNSample' do
             installer,
             config[:reactNativePath],
             :mac_catalyst_enabled => false,
-            # :ccache_enabled => true
+            # :cache_enabled => true
           )
     # XCode14
     installer.pods_project.targets.each do |target|


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[[CLNP-6518]](https://sendbird.atlassian.net/browse/CLNP-6518)

## Description Of Changes

TurboModules in the [New Architecture performs strict type](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/appendix.md ) checking and does not handle native `BOOL` values properly. This likely stems from a marshaling issue.
To support the New Architecture, I’ve changed the type from `BOOL` to `NSNumber`.
Additionally, the use of the `nonnull` keyword is recommended by the React Native team.

Since the New Architecture is enabled by default in the latest version of React Native, I’ve changed new_arch_enabled to true.

I tested on both the simulator and a real device.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply\_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-6518]: https://sendbird.atlassian.net/browse/CLNP-6518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ