### PR TITLE
[CLNP-6700] update android_handleFirebaseMessageData type to Record<string, string> | object

### DIFF
--- a/sample/src/direct-call/callHandler/android.ts
+++ b/sample/src/direct-call/callHandler/android.ts
@@ -11,7 +11,6 @@ import { DirectRouteWithParams, DirectRoutes } from '../navigations/routes';
 /** Firebase RemoteMessage handler **/
 export function setFirebaseMessageHandlers() {
   const firebaseListener = async (message: FirebaseMessagingTypes.RemoteMessage) => {
-    // @ts-ignore
     SendbirdCalls.android_handleFirebaseMessageData(message.data);
   };
   messaging().setBackgroundMessageHandler(firebaseListener);

--- a/src/libs/SendbirdCallsModule.tsx
+++ b/src/libs/SendbirdCallsModule.tsx
@@ -376,32 +376,14 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
    * @platform Android
    * @since 1.0.0
    */
-  public android_handleFirebaseMessageData = (data?: Record<string, string> | object) => {
-    if (Platform.OS !== 'android' || data == null || typeof data !== 'object') {
+  public android_handleFirebaseMessageData = (data?: { [key: string]: string | object }) => {
+    if (Platform.OS !== 'android' || !data?.['sendbird_call']) {
       return false;
+    } else {
+      //@ts-ignore
+      this.binder.nativeModule.handleFirebaseMessageData(data);
+      return true;
     }
-
-    const raw = data as Record<string, unknown>;
-    const sendbirdCall = raw['sendbird_call'];
-    if (typeof sendbirdCall !== 'string') {
-      return false;
-    }
-
-    const record: Record<string, string> = {};
-    for (const [key, val] of Object.entries(raw)) {
-      if (typeof val === 'string') {
-        record[key] = val;
-      } else {
-        try {
-          record[key] = JSON.stringify(val);
-        } catch (e) {
-          Logger.warn(`JSON.stringify failed for key "${key}":`, e);
-        }
-      }
-    }
-
-    this.binder.nativeModule.handleFirebaseMessageData(record);
-    return true;
   };
 
   /**

--- a/src/libs/SendbirdCallsModule.tsx
+++ b/src/libs/SendbirdCallsModule.tsx
@@ -1,6 +1,5 @@
 import { Platform } from 'react-native';
 
-import { AppLogger } from '../../sample/src/shared/utils/logger';
 import type {
   AuthenticateParams,
   CallOptions,
@@ -396,7 +395,7 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
         try {
           record[key] = JSON.stringify(val);
         } catch (e) {
-          AppLogger.warn(`JSON.stringify failed for key "${key}":`, e);
+          Logger.warn(`JSON.stringify failed for key "${key}":`, e);
         }
       }
     }

--- a/src/libs/SendbirdCallsModule.tsx
+++ b/src/libs/SendbirdCallsModule.tsx
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 
+import { AppLogger } from '../../sample/src/shared/utils/logger';
 import type {
   AuthenticateParams,
   CallOptions,
@@ -392,7 +393,11 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
       if (typeof val === 'string') {
         record[key] = val;
       } else {
-        record[key] = JSON.stringify(val);
+        try {
+          record[key] = JSON.stringify(val);
+        } catch (e) {
+          AppLogger.warn(`JSON.stringify failed for key "${key}":`, e);
+        }
       }
     }
 

--- a/src/libs/SendbirdCallsModule.tsx
+++ b/src/libs/SendbirdCallsModule.tsx
@@ -376,13 +376,28 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
    * @platform Android
    * @since 1.0.0
    */
-  public android_handleFirebaseMessageData = (data?: Record<string, string>) => {
-    if (Platform.OS !== 'android' || !data?.['sendbird_call']) {
+  public android_handleFirebaseMessageData = (data?: Record<string, string> | object) => {
+    if (Platform.OS !== 'android' || data == null || typeof data !== 'object') {
       return false;
-    } else {
-      this.binder.nativeModule.handleFirebaseMessageData(data);
-      return true;
     }
+
+    const raw = data as Record<string, unknown>;
+    const sendbirdCall = raw['sendbird_call'];
+    if (typeof sendbirdCall !== 'string') {
+      return false;
+    }
+
+    const record: Record<string, string> = {};
+    for (const [key, val] of Object.entries(raw)) {
+      if (typeof val === 'string') {
+        record[key] = val;
+      } else {
+        record[key] = JSON.stringify(val);
+      }
+    }
+
+    this.binder.nativeModule.handleFirebaseMessageData(record);
+    return true;
   };
 
   /**

--- a/src/types/NativeModule.ts
+++ b/src/types/NativeModule.ts
@@ -49,7 +49,7 @@ export interface NativeCommonModule {
   getCachedRoomById(roomId: string): Promise<RoomProperties | null>;
 
   /** @platform Android **/
-  handleFirebaseMessageData(data: Record<string, string> | object): void;
+  handleFirebaseMessageData(data: Record<string, string>): void;
 
   /** @platform iOS **/
   registerVoIPPushToken(token: string, unique?: boolean): Promise<void>;

--- a/src/types/NativeModule.ts
+++ b/src/types/NativeModule.ts
@@ -49,7 +49,7 @@ export interface NativeCommonModule {
   getCachedRoomById(roomId: string): Promise<RoomProperties | null>;
 
   /** @platform Android **/
-  handleFirebaseMessageData(data: Record<string, string>): void;
+  handleFirebaseMessageData(data: Record<string, string> | object): void;
 
   /** @platform iOS **/
   registerVoIPPushToken(token: string, unique?: boolean): Promise<void>;


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[[CLNP-6700]](https://sendbird.atlassian.net/browse/CLNP-6700)

## Description Of Changes
Since the RemoteMessage.data type in [react-native-firebase v18.5.0 was changed](https://github.com/invertase/react-native-firebase/blob/615abf5441081665897fdb185d23a7641a74481c/CHANGELOG.md#1850-2023-09-22) to Record<string, string> | object, we have updated the parameter type of android_handleFirebaseMessageData accordingly.


## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply\_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-6700]: https://sendbird.atlassian.net/browse/CLNP-6700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ