### PR TITLE
[CLNP-7606] feat/implement-custom-item and android 16kb support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:${ReactNative.ext.getVersion("android", "kotlin")}"
-  implementation("com.sendbird.sdk:sendbird-calls:1.12.1")
+  implementation("com.sendbird.sdk:sendbird-calls:1.12.3")
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsCommonModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsCommonModule.kt
@@ -1,6 +1,7 @@
 package com.sendbird.calls.reactnative.module
 
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.sendbird.calls.*
@@ -223,10 +224,7 @@ class CallsCommonModule(private val root: CallsModule): CommonModule {
 
     override fun updateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) {
         RNCallsLogger.d("[CommonModule] updateCustomItems($callId)")
-        val items = mutableMapOf<String, String>()
-        customItems.entryIterator.forEach { entry ->
-            items[entry.key] = entry.value as String
-        }
+       val items = CallsUtils.convertMapToHashMap(customItems)
 
         SendBirdCall.updateCustomItems(callId, items) { updatedItems, affectedKeys, error ->
             error?.let {
@@ -240,12 +238,9 @@ class CallsCommonModule(private val root: CallsModule): CommonModule {
         }
     }
 
-    override fun deleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) {
+    override fun deleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise) {
         RNCallsLogger.d("[CommonModule] deleteCustomItems($callId)")
-        val keys = mutableSetOf<String>()
-        for (i in 0 until customItemKeys.size()) {
-            keys.add(customItemKeys.getString(i))
-        }
+         val keys = CallsUtils.convertArrayToSet(customItemKeys)
 
         SendBirdCall.deleteCustomItems(callId, keys) { updatedItems, affectedKeys, error ->
             error?.let {

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsCommonModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsCommonModule.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.sendbird.calls.*
+import com.sendbird.calls.internal.PushTokenType
 import com.sendbird.calls.reactnative.RNCallsInternalError
 import com.sendbird.calls.reactnative.extension.rejectCalls
 import com.sendbird.calls.reactnative.module.listener.CallsDirectCallListener
@@ -106,7 +107,7 @@ class CallsCommonModule(private val root: CallsModule): CommonModule {
 
     override fun registerPushToken(token: String, unique: Boolean, promise: Promise) {
         RNCallsLogger.d("[CommonModule] registerPushToken()")
-        SendBirdCall.registerPushToken(token, unique) { error ->
+        SendBirdCall.registerPushToken(token, PushTokenType.FCM_VOIP, unique) { error ->
             error
                 ?.let {
                     promise.rejectCalls(it)
@@ -119,7 +120,7 @@ class CallsCommonModule(private val root: CallsModule): CommonModule {
 
     override fun unregisterPushToken(token: String, promise: Promise) {
         RNCallsLogger.d("[CommonModule] unregisterPushToken()")
-        SendBirdCall.unregisterPushToken(token) { error ->
+        SendBirdCall.unregisterPushToken(token, PushTokenType.FCM_VOIP) { error ->
             error
                 ?.let {
                     promise.rejectCalls(it)

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsCommonModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsCommonModule.kt
@@ -240,7 +240,7 @@ class CallsCommonModule(private val root: CallsModule): CommonModule {
 
     override fun deleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise) {
         RNCallsLogger.d("[CommonModule] deleteCustomItems($callId)")
-         val keys = CallsUtils.convertArrayToSet(customItemKeys)
+        val keys = CallsUtils.convertArrayToSet(customItemKeys)
 
         SendBirdCall.deleteCustomItems(callId, keys) { updatedItems, affectedKeys, error ->
             error?.let {

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsDirectCallModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsDirectCallModule.kt
@@ -1,6 +1,7 @@
 package com.sendbird.calls.reactnative.module
 
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.sendbird.calls.AcceptParams
 import com.sendbird.calls.AudioDevice
@@ -83,7 +84,7 @@ class CallsDirectCallModule(private val root: CallsModule): DirectCallModule {
             call.setRemoteVideoView(view.getSurface())
         }
     }
-    
+
     override fun muteMicrophone(type: String, identifier: String) {
         val from = "directCall/muteMicrophone"
         RNCallsLogger.d("[DirectCallModule] $from ($identifier)")
@@ -223,7 +224,7 @@ class CallsDirectCallModule(private val root: CallsModule): DirectCallModule {
         }
     }
 
-    override fun directCallDeleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) {
+    override fun directCallDeleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise) {
         val from = "directCall/deleteCustomItems"
         RNCallsLogger.d("[DirectCallModule] $from ($callId)")
 

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsDirectCallModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsDirectCallModule.kt
@@ -200,4 +200,69 @@ class CallsDirectCallModule(private val root: CallsModule): DirectCallModule {
             CallsUtils.findDirectCall(identifier, from).resumeAudioTrack()
         }
     }
+
+    override fun directCallUpdateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) {
+        val from = "directCall/updateCustomItems"
+        RNCallsLogger.d("[DirectCallModule] $from ($callId)")
+
+        CallsUtils.safeRun(promise) {
+            val call = CallsUtils.findDirectCall(callId, from)
+            val items = CallsUtils.convertMapToHashMap(customItems)
+
+            call.updateCustomItems(items) { updatedItems, affectedKeys, error ->
+                if (error != null) {
+                    promise.rejectCalls(error)
+                } else {
+                    val result = CallsUtils.createMap().apply {
+                        putMap("updatedItems", CallsUtils.convertHashMapToMap(updatedItems ?: hashMapOf()))
+                        putArray("affectedKeys", CallsUtils.convertListToArray(affectedKeys ?: listOf()))
+                    }
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
+
+    override fun directCallDeleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) {
+        val from = "directCall/deleteCustomItems"
+        RNCallsLogger.d("[DirectCallModule] $from ($callId)")
+
+        CallsUtils.safeRun(promise) {
+            val call = CallsUtils.findDirectCall(callId, from)
+            val keys = CallsUtils.convertArrayToSet(customItemKeys)
+
+            call.deleteCustomItems(keys) { updatedItems, affectedKeys, error ->
+                if (error != null) {
+                    promise.rejectCalls(error)
+                } else {
+                    val result = CallsUtils.createMap().apply {
+                        putMap("updatedItems", CallsUtils.convertHashMapToMap(updatedItems ?: hashMapOf()))
+                        putArray("affectedKeys", CallsUtils.convertListToArray(affectedKeys ?: listOf()))
+                    }
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
+
+    override fun directCallDeleteAllCustomItems(callId: String, promise: Promise) {
+        val from = "directCall/deleteAllCustomItems"
+        RNCallsLogger.d("[DirectCallModule] $from ($callId)")
+
+        CallsUtils.safeRun(promise) {
+            val call = CallsUtils.findDirectCall(callId, from)
+
+            call.deleteAllCustomItems { updatedItems, affectedKeys, error ->
+                if (error != null) {
+                    promise.rejectCalls(error)
+                } else {
+                    val result = CallsUtils.createMap().apply {
+                        putMap("updatedItems", CallsUtils.convertHashMapToMap(updatedItems ?: hashMapOf()))
+                        putArray("affectedKeys", CallsUtils.convertListToArray(affectedKeys ?: listOf()))
+                    }
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
 }

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsGroupCallModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsGroupCallModule.kt
@@ -199,10 +199,8 @@ class CallsGroupCallModule: GroupCallModule {
 
         CallsUtils.safeRun(promise) {
             val room = CallsUtils.findRoom(roomId, from)
-            val allKeys = room.customItems.keys
-
             // There is no deleteAllCustomItems API in Android native, so handled with deleteCustomItems.
-            room.deleteCustomItems(allKeys) { updatedItems, affectedKeys, error ->
+            room.deleteCustomItems(null) { updatedItems, affectedKeys, error ->
                 if (error != null) {
                     promise.rejectCalls(error)
                 } else {

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsGroupCallModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsGroupCallModule.kt
@@ -1,6 +1,7 @@
 package com.sendbird.calls.reactnative.module
 
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.sendbird.calls.*
 import com.sendbird.calls.reactnative.RNCallsInternalError
@@ -170,7 +171,7 @@ class CallsGroupCallModule: GroupCallModule {
         }
     }
 
-    override fun groupCallDeleteCustomItems(roomId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) {
+    override fun groupCallDeleteCustomItems(roomId: String, customItemKeys: ReadableArray, promise: Promise) {
         val from = "groupCall/deleteCustomItems"
         RNCallsLogger.d("[GroupCallModule] $from ($roomId)")
 

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsGroupCallModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsGroupCallModule.kt
@@ -147,4 +147,71 @@ class CallsGroupCallModule: GroupCallModule {
             CallsUtils.findRoom(identifier, from).localParticipant?.resumeAudioTrack()
         }
     }
+
+    override fun groupCallUpdateCustomItems(roomId: String, customItems: ReadableMap, promise: Promise) {
+        val from = "groupCall/updateCustomItems"
+        RNCallsLogger.d("[GroupCallModule] $from ($roomId)")
+
+        CallsUtils.safeRun(promise) {
+            val room = CallsUtils.findRoom(roomId, from)
+            val items = CallsUtils.convertMapToHashMap(customItems)
+
+            room.updateCustomItems(items) { updatedItems, affectedKeys, error ->
+                if (error != null) {
+                    promise.rejectCalls(error)
+                } else {
+                    val result = CallsUtils.createMap().apply {
+                        putMap("updatedItems", CallsUtils.convertHashMapToMap(updatedItems ?: hashMapOf()))
+                        putArray("affectedKeys", CallsUtils.convertListToArray(affectedKeys ?: listOf()))
+                    }
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
+
+    override fun groupCallDeleteCustomItems(roomId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) {
+        val from = "groupCall/deleteCustomItems"
+        RNCallsLogger.d("[GroupCallModule] $from ($roomId)")
+
+        CallsUtils.safeRun(promise) {
+            val room = CallsUtils.findRoom(roomId, from)
+            val keys = CallsUtils.convertArrayToSet(customItemKeys)
+
+            room.deleteCustomItems(keys) { updatedItems, affectedKeys, error ->
+                if (error != null) {
+                    promise.rejectCalls(error)
+                } else {
+                    val result = CallsUtils.createMap().apply {
+                        putMap("updatedItems", CallsUtils.convertHashMapToMap(updatedItems ?: hashMapOf()))
+                        putArray("affectedKeys", CallsUtils.convertListToArray(affectedKeys ?: listOf()))
+                    }
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
+
+    override fun groupCallDeleteAllCustomItems(roomId: String, promise: Promise) {
+        val from = "groupCall/deleteAllCustomItems"
+        RNCallsLogger.d("[GroupCallModule] $from ($roomId)")
+
+        CallsUtils.safeRun(promise) {
+            val room = CallsUtils.findRoom(roomId, from)
+            val allKeys = room.customItems.keys
+
+            // There is no deleteAllCustomItems API in Android native, so handled with deleteCustomItems.
+            room.deleteCustomItems(allKeys) { updatedItems, affectedKeys, error ->
+                if (error != null) {
+                    promise.rejectCalls(error)
+                } else {
+                    val result = CallsUtils.createMap().apply {
+                        putMap("updatedItems", CallsUtils.convertHashMapToMap(updatedItems ?: emptyMap()))
+                        putArray("affectedKeys", CallsUtils.convertListToArray(affectedKeys ?: listOf()))
+                    }
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
 }

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
@@ -2,6 +2,7 @@ package com.sendbird.calls.reactnative.module
 
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.sendbird.calls.DirectCall
 import com.sendbird.calls.RoomInvitation

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
@@ -97,7 +97,7 @@ class CallsModule(val reactContext: ReactApplicationContext) : CallsModuleStruct
     override fun updateLocalVideoView(callId: String, videoViewId: Int)= directCallModule.updateLocalVideoView(callId, videoViewId)
     override fun updateRemoteVideoView(callId: String, videoViewId: Int)= directCallModule.updateRemoteVideoView(callId, videoViewId)
     override fun directCallUpdateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) = directCallModule.directCallUpdateCustomItems(callId, customItems, promise)
-    override fun directCallDeleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) = directCallModule.directCallDeleteCustomItems(callId, customItemKeys, promise)
+    override fun directCallDeleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise) = directCallModule.directCallDeleteCustomItems(callId, customItemKeys, promise)
     override fun directCallDeleteAllCustomItems(callId: String, promise: Promise) = directCallModule.directCallDeleteAllCustomItems(callId, promise)
 
     /** GroupCall module interface**/

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
@@ -76,6 +76,9 @@ class CallsModule(val reactContext: ReactApplicationContext) : CallsModuleStruct
     override fun createRoom(params: ReadableMap, promise: Promise) = commonModule.createRoom(params, promise)
     override fun fetchRoomById(roomId: String, promise: Promise) = commonModule.fetchRoomById(roomId, promise)
     override fun getCachedRoomById(roomId: String, promise: Promise) = commonModule.getCachedRoomById(roomId, promise)
+    override fun updateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) = commonModule.updateCustomItems(callId, customItems, promise)
+    override fun deleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) = commonModule.deleteCustomItems(callId, customItemKeys, promise)
+    override fun deleteAllCustomItems(callId: String, promise: Promise) = commonModule.deleteAllCustomItems(callId, promise)
 
     /** Media Device control interface **/
     override fun stopVideo(type: String, identifier: String) = getControllableModule(type).stopVideo(type, identifier)
@@ -93,10 +96,16 @@ class CallsModule(val reactContext: ReactApplicationContext) : CallsModuleStruct
     override fun end(callId: String, promise: Promise)= directCallModule.end(callId, promise)
     override fun updateLocalVideoView(callId: String, videoViewId: Int)= directCallModule.updateLocalVideoView(callId, videoViewId)
     override fun updateRemoteVideoView(callId: String, videoViewId: Int)= directCallModule.updateRemoteVideoView(callId, videoViewId)
+    override fun directCallUpdateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) = directCallModule.directCallUpdateCustomItems(callId, customItems, promise)
+    override fun directCallDeleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) = directCallModule.directCallDeleteCustomItems(callId, customItemKeys, promise)
+    override fun directCallDeleteAllCustomItems(callId: String, promise: Promise) = directCallModule.directCallDeleteAllCustomItems(callId, promise)
 
     /** GroupCall module interface**/
     override fun enter(roomId: String, options: ReadableMap, promise: Promise) = groupCallModule.enter(roomId, options, promise)
     override fun exit(roomId: String) = groupCallModule.exit(roomId)
+    override fun groupCallUpdateCustomItems(roomId: String, customItems: ReadableMap, promise: Promise) = groupCallModule.groupCallUpdateCustomItems(roomId, customItems, promise)
+    override fun groupCallDeleteCustomItems(roomId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) = groupCallModule.groupCallDeleteCustomItems(roomId, customItemKeys, promise)
+    override fun groupCallDeleteAllCustomItems(roomId: String, promise: Promise) = groupCallModule.groupCallDeleteAllCustomItems(roomId, promise)
 
     /** Queries **/
     fun createDirectCallLogListQuery(params: ReadableMap, promise: Promise) = queries.createDirectCallLogListQuery(params, promise)

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
@@ -77,7 +77,7 @@ class CallsModule(val reactContext: ReactApplicationContext) : CallsModuleStruct
     override fun fetchRoomById(roomId: String, promise: Promise) = commonModule.fetchRoomById(roomId, promise)
     override fun getCachedRoomById(roomId: String, promise: Promise) = commonModule.getCachedRoomById(roomId, promise)
     override fun updateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) = commonModule.updateCustomItems(callId, customItems, promise)
-    override fun deleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) = commonModule.deleteCustomItems(callId, customItemKeys, promise)
+    override fun deleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise) = commonModule.deleteCustomItems(callId, customItemKeys, promise)
     override fun deleteAllCustomItems(callId: String, promise: Promise) = commonModule.deleteAllCustomItems(callId, promise)
 
     /** Media Device control interface **/

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModule.kt
@@ -104,7 +104,7 @@ class CallsModule(val reactContext: ReactApplicationContext) : CallsModuleStruct
     override fun enter(roomId: String, options: ReadableMap, promise: Promise) = groupCallModule.enter(roomId, options, promise)
     override fun exit(roomId: String) = groupCallModule.exit(roomId)
     override fun groupCallUpdateCustomItems(roomId: String, customItems: ReadableMap, promise: Promise) = groupCallModule.groupCallUpdateCustomItems(roomId, customItems, promise)
-    override fun groupCallDeleteCustomItems(roomId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise) = groupCallModule.groupCallDeleteCustomItems(roomId, customItemKeys, promise)
+    override fun groupCallDeleteCustomItems(roomId: String, customItemKeys: ReadableArray, promise: Promise) = groupCallModule.groupCallDeleteCustomItems(roomId, customItemKeys, promise)
     override fun groupCallDeleteAllCustomItems(roomId: String, promise: Promise) = groupCallModule.groupCallDeleteAllCustomItems(roomId, promise)
 
     /** Queries **/

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
@@ -1,6 +1,7 @@
 package com.sendbird.calls.reactnative.module
 
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 
 interface CallsModuleStruct: CommonModule, DirectCallModule, GroupCallModule { }

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
@@ -41,7 +41,7 @@ interface DirectCallModule: MediaDeviceControl {
     fun updateLocalVideoView(callId: String, videoViewId: Int)
     fun updateRemoteVideoView(callId: String, videoViewId: Int)
     fun directCallUpdateCustomItems(callId: String, customItems: ReadableMap, promise: Promise)
-    fun directCallDeleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise)
+    fun directCallDeleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise)
     fun directCallDeleteAllCustomItems(callId: String, promise: Promise)
 }
 

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
@@ -29,6 +29,10 @@ interface CommonModule {
     fun createRoom(params: ReadableMap, promise: Promise)
     fun fetchRoomById(roomId: String, promise: Promise)
     fun getCachedRoomById(roomId: String, promise: Promise)
+
+    fun updateCustomItems(callId: String, customItems: ReadableMap, promise: Promise)
+    fun deleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise)
+    fun deleteAllCustomItems(callId: String, promise: Promise)
 }
 
 interface DirectCallModule: MediaDeviceControl {
@@ -36,11 +40,17 @@ interface DirectCallModule: MediaDeviceControl {
     fun end(callId: String, promise: Promise)
     fun updateLocalVideoView(callId: String, videoViewId: Int)
     fun updateRemoteVideoView(callId: String, videoViewId: Int)
+    fun directCallUpdateCustomItems(callId: String, customItems: ReadableMap, promise: Promise)
+    fun directCallDeleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise)
+    fun directCallDeleteAllCustomItems(callId: String, promise: Promise)
 }
 
 interface GroupCallModule: MediaDeviceControl {
     fun enter(roomId: String, options: ReadableMap, promise: Promise)
     fun exit(roomId: String)
+    fun groupCallUpdateCustomItems(roomId: String, customItems: ReadableMap, promise: Promise)
+    fun groupCallDeleteCustomItems(roomId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise)
+    fun groupCallDeleteAllCustomItems(roomId: String, promise: Promise)
 }
 
 enum class ControllableModuleType {

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
@@ -49,7 +49,7 @@ interface GroupCallModule: MediaDeviceControl {
     fun enter(roomId: String, options: ReadableMap, promise: Promise)
     fun exit(roomId: String)
     fun groupCallUpdateCustomItems(roomId: String, customItems: ReadableMap, promise: Promise)
-    fun groupCallDeleteCustomItems(roomId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise)
+    fun groupCallDeleteCustomItems(roomId: String, customItemKeys: ReadableArray, promise: Promise)
     fun groupCallDeleteAllCustomItems(roomId: String, promise: Promise)
 }
 

--- a/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/module/CallsModuleStruct.kt
@@ -31,7 +31,7 @@ interface CommonModule {
     fun getCachedRoomById(roomId: String, promise: Promise)
 
     fun updateCustomItems(callId: String, customItems: ReadableMap, promise: Promise)
-    fun deleteCustomItems(callId: String, customItemKeys: com.facebook.react.bridge.ReadableArray, promise: Promise)
+    fun deleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise)
     fun deleteAllCustomItems(callId: String, promise: Promise)
 }
 

--- a/android/src/main/java/com/sendbird/calls/reactnative/utils/CallsUtils.kt
+++ b/android/src/main/java/com/sendbird/calls/reactnative/utils/CallsUtils.kt
@@ -252,4 +252,50 @@ object CallsUtils {
         return SendBirdCall.getCachedRoomById(roomId) ?: throw RNCallsInternalError(from, RNCallsInternalError.Type.NOT_FOUND_ROOM)
     }
 
+    fun createMap(): WritableNativeMap {
+        return WritableNativeMap()
+    }
+
+    fun convertMapToHashMap(map: ReadableMap): HashMap<String, String> {
+        val hashMap = HashMap<String, String>()
+        val iterator = map.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            hashMap[key] = map.getString(key) ?: ""
+        }
+        return hashMap
+    }
+
+    fun convertHashMapToMap(hashMap: Map<String, String>): WritableNativeMap {
+        val map = WritableNativeMap()
+        for ((key, value) in hashMap) {
+            map.putString(key, value)
+        }
+        return map
+    }
+
+    fun convertArrayToSet(array: ReadableArray): Set<String> {
+        val set = mutableSetOf<String>()
+        for (i in 0 until array.size()) {
+            set.add(array.getString(i))
+        }
+        return set
+    }
+
+    fun convertArrayToList(array: ReadableArray): List<String> {
+        val list = mutableListOf<String>()
+        for (i in 0 until array.size()) {
+            list.add(array.getString(i))
+        }
+        return list
+    }
+
+    fun convertListToArray(list: List<String>): WritableNativeArray {
+        val array = WritableNativeArray()
+        for (item in list) {
+            array.pushString(item)
+        }
+        return array
+    }
+
 }

--- a/android/src/oldarch/java/com/sendbird/calls/reactnative/RNSendbirdCallsModule.kt
+++ b/android/src/oldarch/java/com/sendbird/calls/reactnative/RNSendbirdCallsModule.kt
@@ -75,6 +75,12 @@ class RNSendbirdCallsModule(private val reactContext: ReactApplicationContext) :
     override fun fetchRoomById(roomId: String, promise: Promise) = module.fetchRoomById(roomId, promise)
     @ReactMethod
     override fun getCachedRoomById(roomId: String, promise: Promise) = module.getCachedRoomById(roomId, promise)
+    @ReactMethod
+    override fun updateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) = module.updateCustomItems(callId, customItems, promise)
+    @ReactMethod
+    override fun deleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise) = module.deleteCustomItems(callId, customItemKeys, promise)
+    @ReactMethod
+    override fun deleteAllCustomItems(callId: String, promise: Promise) = module.deleteAllCustomItems(callId, promise)
 
     /** MediaDevice Control **/
     @ReactMethod
@@ -106,11 +112,25 @@ class RNSendbirdCallsModule(private val reactContext: ReactApplicationContext) :
     @ReactMethod
     override fun updateRemoteVideoView(callId: String, videoViewId: Int) = module.updateRemoteVideoView(callId, videoViewId)
 
+    @ReactMethod
+    override fun directCallUpdateCustomItems(callId: String, customItems: ReadableMap, promise: Promise) = module.directCallUpdateCustomItems(callId, customItems, promise)
+    @ReactMethod
+    override fun directCallDeleteCustomItems(callId: String, customItemKeys: ReadableArray, promise: Promise) = module.directCallDeleteCustomItems(callId, customItemKeys, promise)
+    @ReactMethod
+    override fun directCallDeleteAllCustomItems(callId: String, promise: Promise) = module.directCallDeleteAllCustomItems(callId, promise)
+
     /** GroupCall - Room **/
     @ReactMethod
     override fun enter(roomId: String, options: ReadableMap, promise: Promise) = module.enter(roomId, options, promise)
     @ReactMethod
     override fun exit(roomId: String) = module.exit(roomId)
+
+    @ReactMethod
+    override fun groupCallUpdateCustomItems(roomId: String, customItems: ReadableMap, promise: Promise) = module.groupCallUpdateCustomItems(roomId, customItems, promise)
+    @ReactMethod
+    override fun groupCallDeleteCustomItems(roomId: String, customItemKeys: ReadableArray, promise: Promise) = module.groupCallDeleteCustomItems(roomId, customItemKeys, promise)
+    @ReactMethod
+    override fun groupCallDeleteAllCustomItems(roomId: String, promise: Promise) = module.groupCallDeleteAllCustomItems(roomId, promise)
 
     /** Queries **/
     @ReactMethod

--- a/ios/Modules/CallsModule+Common.swift
+++ b/ios/Modules/CallsModule+Common.swift
@@ -37,6 +37,10 @@ protocol CallsCommonModuleProtocol {
     func fetchRoomById(_ roomId: String, _ promise: Promise)
     func getCachedRoomById(_ roomId: String, _ promise: Promise)
     func createRoom(_ params: [String: Any], _ promise: Promise)
+
+    func updateCustomItems(_ callId: String, _ customItems: [String: String], _ promise: Promise)
+    func deleteCustomItems(_ callId: String, _ customItemKeys: [String], _ promise: Promise)
+    func deleteAllCustomItems(_ callId: String, _ promise: Promise)
 }
 
 class CallsCommonModule: CallsBaseModule, CallsCommonModuleProtocol {
@@ -224,6 +228,48 @@ class CallsCommonModule: CallsBaseModule, CallsCommonModuleProtocol {
             } else if let room = room {
                 room.addDelegate(GroupCallDelegate.get(room), identifier: room.roomId)
                 promise.resolve(CallsUtils.convertRoomToDict(room))
+            }
+        }
+    }
+
+    func updateCustomItems(_ callId: String, _ customItems: [String: String], _ promise: Promise) {
+        SendBirdCall.updateCustomItems(callId: callId, customItems: customItems) { result, affectedKeys, error in
+            if let error = error {
+                promise.reject(error)
+            } else {
+                let customItemsResult: [String: Any] = [
+                    "updatedItems": result ?? [:],
+                    "affectedKeys": affectedKeys ?? []
+                ]
+                promise.resolve(customItemsResult)
+            }
+        }
+    }
+
+    func deleteCustomItems(_ callId: String, _ customItemKeys: [String], _ promise: Promise) {
+        SendBirdCall.deleteCustomItems(callId: callId, customItemKeys: customItemKeys) { result, affectedKeys, error in
+            if let error = error {
+                promise.reject(error)
+            } else {
+                let customItemsResult: [String: Any] = [
+                    "updatedItems": result ?? [:],
+                    "affectedKeys": affectedKeys ?? []
+                ]
+                promise.resolve(customItemsResult)
+            }
+        }
+    }
+
+    func deleteAllCustomItems(_ callId: String, _ promise: Promise) {
+        SendBirdCall.deleteAllCustomItems(callId: callId) { result, affectedKeys, error in
+            if let error = error {
+                promise.reject(error)
+            } else {
+                let customItemsResult: [String: Any] = [
+                    "updatedItems": result ?? [:],
+                    "affectedKeys": affectedKeys ?? []
+                ]
+                promise.resolve(customItemsResult)
             }
         }
     }

--- a/ios/Modules/CallsModule+DirectCall.swift
+++ b/ios/Modules/CallsModule+DirectCall.swift
@@ -16,6 +16,9 @@ protocol CallsDirectCallModuleProtocol: MediaDeviceControlProtocol {
     func end(_ callId: String, _ promise: Promise)
     func updateLocalVideoView(_ callId: String, _ videoViewId: NSNumber)
     func updateRemoteVideoView(_ callId: String, _ videoViewId: NSNumber)
+    func directCallUpdateCustomItems(_ callId: String, _ customItems: [String: String], _ promise: Promise)
+    func directCallDeleteCustomItems(_ callId: String, _ customItemKeys: [String], _ promise: Promise)
+    func directCallDeleteAllCustomItems(_ callId: String, _ promise: Promise)
 }
 
 // MARK: DirectCallMethods
@@ -55,6 +58,60 @@ class CallsDirectCallModule: CallsBaseModule, CallsDirectCallModuleProtocol {
             let directCall = try CallsUtils.findDirectCallBy(callId)
             let videoView = try CallsUtils.findViewBy(CallsEvents.shared.bridge, videoViewId)
             directCall.updateRemoteVideoView(videoView.surface)
+        }
+    }
+
+    func directCallUpdateCustomItems(_ callId: String, _ customItems: [String: String], _ promise: Promise) {
+        if let directCall = try? CallsUtils.findDirectCallBy(callId) {
+            directCall.updateCustomItems(customItems: customItems) { updatedItems, affectedKeys, error in
+                if let error = error {
+                    promise.reject(error)
+                } else {
+                    let result: [String: Any] = [
+                        "updatedItems": updatedItems ?? [:],
+                        "affectedKeys": affectedKeys ?? []
+                    ]
+                    promise.resolve(result)
+                }
+            }
+        } else {
+            promise.reject(RNCallsInternalError.notFoundDirectCall("directCall/updateCustomItems"))
+        }
+    }
+
+    func directCallDeleteCustomItems(_ callId: String, _ customItemKeys: [String], _ promise: Promise) {
+        if let directCall = try? CallsUtils.findDirectCallBy(callId) {
+            directCall.deleteCustomItems(customItemKeys: customItemKeys) { updatedItems, affectedKeys, error in
+                if let error = error {
+                    promise.reject(error)
+                } else {
+                    let result: [String: Any] = [
+                        "updatedItems": updatedItems ?? [:],
+                        "affectedKeys": affectedKeys ?? []
+                    ]
+                    promise.resolve(result)
+                }
+            }
+        } else {
+            promise.reject(RNCallsInternalError.notFoundDirectCall("directCall/deleteCustomItems"))
+        }
+    }
+
+    func directCallDeleteAllCustomItems(_ callId: String, _ promise: Promise) {
+        if let directCall = try? CallsUtils.findDirectCallBy(callId) {
+            directCall.deleteAllCustomItems { updatedItems, affectedKeys, error in
+                if let error = error {
+                    promise.reject(error)
+                } else {
+                    let result: [String: Any] = [
+                        "updatedItems": updatedItems ?? [:],
+                        "affectedKeys": affectedKeys ?? []
+                    ]
+                    promise.resolve(result)
+                }
+            }
+        } else {
+            promise.reject(RNCallsInternalError.notFoundDirectCall("directCall/deleteAllCustomItems"))
         }
     }
 }

--- a/ios/Modules/CallsModule+GroupCall.swift
+++ b/ios/Modules/CallsModule+GroupCall.swift
@@ -149,4 +149,3 @@ extension CallsGroupCallModule {
     }
 }
 
-// MARK: GroupCall CustomItems

--- a/ios/Modules/CallsModule+GroupCall.swift
+++ b/ios/Modules/CallsModule+GroupCall.swift
@@ -148,8 +148,3 @@ extension CallsGroupCallModule {
         promise.resolve()
     }
 }
-
-// MARK: GroupCall CustomItems
-extension CallsGroupCallModule {
-
-}

--- a/ios/Modules/CallsModule+GroupCall.swift
+++ b/ios/Modules/CallsModule+GroupCall.swift
@@ -13,6 +13,9 @@ import CallKit
 protocol CallsGroupCallModuleProtocol: MediaDeviceControlProtocol {
     func enter(_ roomId: String, _ options: [String: Any?], _ promise: Promise)
     func exit(_ roomId: String)
+    func groupCallUpdateCustomItems(_ roomId: String, _ customItems: [String: String], _ promise: Promise)
+    func groupCallDeleteCustomItems(_ roomId: String, _ customItemKeys: [String], _ promise: Promise)
+    func groupCallDeleteAllCustomItems(_ roomId: String, _ promise: Promise)
 }
 
 // MARK: GroupCallMethods
@@ -21,12 +24,12 @@ class CallsGroupCallModule: CallsBaseModule, CallsGroupCallModuleProtocol {
         if let room = try? CallsUtils.findRoom(roomId) {
             var isAudioEnabled = true
             var isVideoEnabled = true
-            
+
             if let audioEnabled = options["audioEnabled"] as? Bool { isAudioEnabled = audioEnabled }
             if let videoEnabled = options["videoEnabled"] as? Bool { isVideoEnabled = videoEnabled }
-            
+
             let params = Room.EnterParams(isVideoEnabled: isVideoEnabled, isAudioEnabled: isAudioEnabled)
-            
+
             room.enter(with: params) { error in
                 if let error = error {
                     promise.reject(error)
@@ -38,10 +41,61 @@ class CallsGroupCallModule: CallsBaseModule, CallsGroupCallModuleProtocol {
             promise.reject(RNCallsInternalError.notFoundRoom("groupCall/enter"))
         }
     }
-    
+
     func exit(_ roomId: String) {
         CallsUtils.safeRun {
             try CallsUtils.findRoom(roomId).exit()
+        }
+    }
+
+    func groupCallUpdateCustomItems(_ roomId: String, _ customItems: [String: String], _ promise: Promise) {
+        CallsUtils.safeRun {
+            let room = try CallsUtils.findRoom(roomId)
+            room.updateCustomItems(customItems: customItems) { customItems, affectedKeys, error in
+                if let error = error {
+                    promise.reject(error)
+                } else {
+                    let result = [
+                        "updatedItems": customItems ?? [:],
+                        "affectedKeys": affectedKeys ?? []
+                    ] as [String : Any]
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
+
+    func groupCallDeleteCustomItems(_ roomId: String, _ customItemKeys: [String], _ promise: Promise) {
+        CallsUtils.safeRun {
+            let room = try CallsUtils.findRoom(roomId)
+            room.deleteCustomItems(customItemKeys: customItemKeys.compactMap { $0 }) { customItems, affectedKeys, error in
+                if let error = error {
+                    promise.reject(error)
+                } else {
+                    let result = [
+                        "updatedItems": customItems ?? [:],
+                        "affectedKeys": affectedKeys ?? []
+                    ] as [String : Any]
+                    promise.resolve(result)
+                }
+            }
+        }
+    }
+
+    func groupCallDeleteAllCustomItems(_ roomId: String, _ promise: Promise) {
+        CallsUtils.safeRun {
+            let room = try CallsUtils.findRoom(roomId)
+            room.deleteAllCustomItems { customItems, affectedKeys, error in
+                if let error = error {
+                    promise.reject(error)
+                } else {
+                    let result = [
+                        "updatedItems": customItems ?? [:],
+                        "affectedKeys": affectedKeys ?? []
+                    ] as [String : Any]
+                    promise.resolve(result)
+                }
+            }
         }
     }
 }
@@ -60,37 +114,42 @@ extension CallsGroupCallModule {
             }
         }
     }
-    
+
     func startVideo(_ type: String, _ roomId: String) {
         CallsUtils.safeRun {
             let room = try CallsUtils.findRoom(roomId)
             room.localParticipant?.startVideo()
         }
     }
-    
+
     func stopVideo(_ type: String, _ roomId: String) {
         CallsUtils.safeRun {
             let room = try CallsUtils.findRoom(roomId)
             room.localParticipant?.stopVideo()
         }
     }
-    
+
     func muteMicrophone(_ type: String, _ roomId: String) {
         CallsUtils.safeRun {
             let room = try CallsUtils.findRoom(roomId)
             room.localParticipant?.muteMicrophone()
         }
     }
-    
+
     func unmuteMicrophone(_ type: String, _ roomId: String) {
         CallsUtils.safeRun {
             let room = try CallsUtils.findRoom(roomId)
             room.localParticipant?.unmuteMicrophone()
         }
     }
-    
+
     func selectVideoDevice(_ type: String, _ roomId: String, _ device: [String: String], _ promise: Promise) {
         // NOOP
         promise.resolve()
     }
+}
+
+// MARK: GroupCall CustomItems
+extension CallsGroupCallModule {
+
 }

--- a/ios/Modules/CallsModule.swift
+++ b/ios/Modules/CallsModule.swift
@@ -20,35 +20,35 @@ class CallsBaseModule: NSObject {
 
 class CallsModule: SendBirdCallDelegate {
     internal var queries = CallsQueries()
-    
+
     internal lazy var commonModule: CallsCommonModule = {
         CallsCommonModule(root: self)
     }()
-    
+
     internal lazy var directCallModule: CallsDirectCallModule = {
         CallsDirectCallModule(root: self)
     }()
-    
+
     internal lazy var groupCallModule: CallsGroupCallModule = {
         CallsGroupCallModule(root: self)
     }()
-    
+
     internal var initialized: Bool {
         get {
             return SendBirdCall.appId != nil
         }
     }
-    
+
     init() {
         SendBirdCall.addDelegate(self, identifier: "sendbird.call.listener")
     }
-    
+
     func invalidate() {
         SendBirdCall.removeDirectCallSound(forType: .ringing)
         SendBirdCall.removeDirectCallSound(forType: .dialing)
         SendBirdCall.removeDirectCallSound(forType: .reconnected)
         SendBirdCall.removeDirectCallSound(forType: .reconnecting)
-        
+
         if(initialized){
             SendBirdCall.deauthenticate(completionHandler: nil)
             SendBirdCall.removeAllDelegates()
@@ -57,7 +57,7 @@ class CallsModule: SendBirdCallDelegate {
             GroupCallDelegate.invalidate()
         }
     }
-    
+
     func didStartRinging(_ call: DirectCall) {
         DispatchQueue.main.async {
             CallsEvents.shared.sendEvent(.default(.onRinging), CallsUtils.convertDirectCallToDict(call))
@@ -71,73 +71,85 @@ extension CallsModule: CallsCommonModuleProtocol {
     func setLoggerLevel(_ level: String) {
         commonModule.setLoggerLevel(level)
     }
-    
+
     func addDirectCallSound(_ type: String, _ fileName: String) {
         commonModule.addDirectCallSound(type, fileName)
     }
-    
+
     func removeDirectCallSound(_ type: String) {
         commonModule.removeDirectCallSound(type)
     }
-    
+
     func setDirectCallDialingSoundOnWhenSilentOrVibrateMode(_ enabled: Bool) {
         commonModule.setDirectCallDialingSoundOnWhenSilentOrVibrateMode(enabled)
     }
-    
+
     func getCurrentUser(_ promise: Promise) {
         commonModule.getCurrentUser(promise)
     }
-    
+
     func getOngoingCalls(_ promise: Promise) {
         commonModule.getOngoingCalls(promise)
     }
-    
+
     func getDirectCall(_ callIdOrUUID: String, _ promise: Promise) {
         commonModule.getDirectCall(callIdOrUUID, promise)
     }
-    
+
     func initialize(_ appId: String) -> Bool {
         return commonModule.initialize(appId)
     }
-    
+
     func authenticate(_ authParams: [String: Any?], _ promise: Promise) {
         commonModule.authenticate(authParams, promise)
     }
-    
+
     func deauthenticate(_ promise: Promise) {
         commonModule.deauthenticate(promise)
     }
-    
+
     func registerPushToken(_ token: String, _ unique: Bool, _ promise: Promise) {
         commonModule.registerPushToken(token, unique, promise)
     }
-    
+
     func unregisterPushToken(_ token: String, _ promise: Promise) {
         commonModule.unregisterPushToken(token, promise)
     }
-    
+
     func registerVoIPPushToken(_ token: String, _ unique: Bool, _ promise: Promise) {
         commonModule.registerVoIPPushToken(token, unique, promise)
     }
-    
+
     func unregisterVoIPPushToken(_ token: String, _ promise: Promise) {
         commonModule.unregisterVoIPPushToken(token, promise)
     }
-    
+
     func dial(_ calleeId: String, _ isVideoCall: Bool, _ options: [String: Any?], _ promise: Promise) {
         commonModule.dial(calleeId, isVideoCall, options, promise)
     }
-    
+
     func fetchRoomById(_ roomId: String, _ promise: Promise) {
         commonModule.fetchRoomById(roomId, promise)
     }
-    
+
     func getCachedRoomById(_ roomId: String, _ promise: Promise) {
         commonModule.getCachedRoomById(roomId, promise)
     }
-    
+
     func createRoom(_ params: [String: Any], _ promise: Promise) {
         commonModule.createRoom(params, promise)
+    }
+
+    func updateCustomItems(_ callId: String, _ customItems: [String: String], _ promise: Promise) {
+        commonModule.updateCustomItems(callId, customItems, promise)
+    }
+
+    func deleteCustomItems(_ callId: String, _ customItemKeys: [String], _ promise: Promise) {
+        commonModule.deleteCustomItems(callId, customItemKeys, promise)
+    }
+
+    func deleteAllCustomItems(_ callId: String, _ promise: Promise) {
+        commonModule.deleteAllCustomItems(callId, promise)
     }
 }
 
@@ -146,30 +158,30 @@ extension CallsModule {
     func switchCamera(_ type: String, _ identifier: String, _ promise: Promise) {
         getControllableModule(type)?.switchCamera(type, identifier, promise)
     }
-    
+
     func startVideo(_ type: String, _ identifier: String) {
         getControllableModule(type)?.startVideo(type, identifier)
     }
-    
+
     func stopVideo(_ type: String, _ identifier: String) {
         getControllableModule(type)?.stopVideo(type, identifier)
     }
-    
+
     func muteMicrophone(_ type: String, _ identifier: String) {
         getControllableModule(type)?.muteMicrophone(type, identifier)
     }
-    
+
     func unmuteMicrophone(_ type: String, _ identifier: String) {
         getControllableModule(type)?.unmuteMicrophone(type, identifier)
     }
-    
+
     func selectVideoDevice(_ type: String, _ identifier: String, _ device: [String: String], _ promise: Promise) {
         getControllableModule(type)?.selectVideoDevice(type, identifier, device, promise)
     }
-    
+
     private func getControllableModule(_ type: String) -> MediaDeviceControlProtocol? {
         guard let type = ControllableModuleType(fromString: type) else { return nil }
-        
+
         switch(type) {
         case .directCall:
             return directCallModule
@@ -184,17 +196,29 @@ extension CallsModule: CallsDirectCallModuleProtocol {
     func accept(_ callId: String, _ options: [String : Any?], _ holdActiveCall: Bool, _ promise: Promise) {
         directCallModule.accept(callId, options, holdActiveCall, promise)
     }
-    
+
     func end(_ callId: String, _ promise: Promise) {
         directCallModule.end(callId, promise)
     }
-    
+
     func updateLocalVideoView(_ callId: String, _ videoViewId: NSNumber) {
         directCallModule.updateLocalVideoView(callId, videoViewId)
     }
-    
+
     func updateRemoteVideoView(_ callId: String, _ videoViewId: NSNumber) {
         directCallModule.updateRemoteVideoView(callId, videoViewId)
+    }
+
+    func directCallUpdateCustomItems(_ callId: String, _ customItems: [String: String], _ promise: Promise) {
+        directCallModule.directCallUpdateCustomItems(callId, customItems, promise)
+    }
+
+    func directCallDeleteCustomItems(_ callId: String, _ customItemKeys: [String], _ promise: Promise) {
+        directCallModule.directCallDeleteCustomItems(callId, customItemKeys, promise)
+    }
+
+    func directCallDeleteAllCustomItems(_ callId: String, _ promise: Promise) {
+        directCallModule.directCallDeleteAllCustomItems(callId, promise)
     }
 }
 
@@ -203,9 +227,21 @@ extension CallsModule: CallsGroupCallModuleProtocol {
     func enter(_ roomId: String, _ options: [String : Any?], _ promise: Promise) {
         groupCallModule.enter(roomId, options, promise)
     }
-    
+
     func exit(_ roomId: String) {
         groupCallModule.exit(roomId)
+    }
+
+    func groupCallUpdateCustomItems(_ roomId: String, _ customItems: [String: String], _ promise: Promise) {
+        groupCallModule.groupCallUpdateCustomItems(roomId, customItems, promise)
+    }
+
+    func groupCallDeleteCustomItems(_ roomId: String, _ customItemKeys: [String], _ promise: Promise) {
+        groupCallModule.groupCallDeleteCustomItems(roomId, customItemKeys, promise)
+    }
+
+    func groupCallDeleteAllCustomItems(_ roomId: String, _ promise: Promise) {
+        groupCallModule.groupCallDeleteAllCustomItems(roomId, promise)
     }
 }
 

--- a/ios/RNSendbirdCalls.m
+++ b/ios/RNSendbirdCalls.m
@@ -126,6 +126,23 @@ RCT_EXTERN_METHOD(createRoom
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(updateCustomItems
+                  : (NSString *)callId
+                  : (NSDictionary *)customItems
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(deleteCustomItems
+                  : (NSString *)callId
+                  : (NSArray *)customItemKeys
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(deleteAllCustomItems
+                  : (NSString *)callId
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
 // MARK: - SendbirdCalls: DirectCall
 RCT_EXTERN_METHOD(accept
                   : (NSString *)callId
@@ -147,6 +164,23 @@ RCT_EXTERN_METHOD(updateRemoteVideoView
                   : (NSString *)callId
                   : (nonnull NSNumber *)videoViewId)
 
+RCT_EXTERN_METHOD(directCallUpdateCustomItems
+                  : (NSString *)callId
+                  : (NSDictionary *)customItems
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(directCallDeleteCustomItems
+                  : (NSString *)callId
+                  : (NSArray *)customItemKeys
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(directCallDeleteAllCustomItems
+                  : (NSString *)callId
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
 // MARK: - SendbirdCalls: GroupCall
 RCT_EXTERN_METHOD(enter
                   : (NSString *)roomId
@@ -156,6 +190,23 @@ RCT_EXTERN_METHOD(enter
 
 RCT_EXTERN_METHOD(exit
                   : (NSString *)roomId)
+
+RCT_EXTERN_METHOD(groupCallUpdateCustomItems
+                  : (NSString *)roomId
+                  : (NSDictionary *)customItems
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(groupCallDeleteCustomItems
+                  : (NSString *)roomId
+                  : (NSArray *)customItemKeys
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(groupCallDeleteAllCustomItems
+                  : (NSString *)roomId
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject)
 
 // MARK: - SendbirdCalls: MediaDeviceControl
 RCT_EXTERN_METHOD(switchCamera

--- a/ios/RNSendbirdCalls.swift
+++ b/ios/RNSendbirdCalls.swift
@@ -159,6 +159,18 @@ extension RNSendbirdCalls {
     @objc func createRoom(_ params: [String: Any], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
         module.createRoom(params, Promise(resolve, reject))
     }
+
+    @objc func updateCustomItems(_ callId: String, _ customItems: [String: String], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.updateCustomItems(callId, customItems, Promise(resolve, reject))
+    }
+
+    @objc func deleteCustomItems(_ callId: String, _ customItemKeys: [String], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.deleteCustomItems(callId, customItemKeys, Promise(resolve, reject))
+    }
+
+    @objc func deleteAllCustomItems(_ callId: String, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.deleteAllCustomItems(callId, Promise(resolve, reject))
+    }
 }
 
 // MARK: DirectCall
@@ -178,6 +190,18 @@ extension RNSendbirdCalls {
     @objc func updateRemoteVideoView(_ callId: String, _ videoViewId: NSNumber) {
         module.updateRemoteVideoView(callId, videoViewId)
     }
+
+    @objc func directCallUpdateCustomItems(_ callId: String, _ customItems: [String: String], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.directCallUpdateCustomItems(callId, customItems, Promise(resolve, reject))
+    }
+
+    @objc func directCallDeleteCustomItems(_ callId: String, _ customItemKeys: [String], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.directCallDeleteCustomItems(callId, customItemKeys, Promise(resolve, reject))
+    }
+
+    @objc func directCallDeleteAllCustomItems(_ callId: String, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.directCallDeleteAllCustomItems(callId, Promise(resolve, reject))
+    }
 }
 
 // MARK: GroupCall
@@ -185,9 +209,21 @@ extension RNSendbirdCalls {
     @objc func enter(_ roomId: String, _ options: [String: Any], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
         module.enter(roomId, options, Promise(resolve, reject))
     }
-    
+
     @objc func exit(_ roomId: String) {
         module.exit(roomId)
+    }
+
+    @objc func groupCallUpdateCustomItems(_ roomId: String, _ customItems: [String: String], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.groupCallUpdateCustomItems(roomId, customItems, Promise(resolve, reject))
+    }
+
+    @objc func groupCallDeleteCustomItems(_ roomId: String, _ customItemKeys: [String], _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.groupCallDeleteCustomItems(roomId, customItemKeys, Promise(resolve, reject))
+    }
+
+    @objc func groupCallDeleteAllCustomItems(_ roomId: String, _ resolve: @escaping RCTPromiseResolveBlock, _ reject: @escaping RCTPromiseRejectBlock) {
+        module.groupCallDeleteAllCustomItems(roomId, Promise(resolve, reject))
     }
 }
 

--- a/src/libs/DirectCall.ts
+++ b/src/libs/DirectCall.ts
@@ -30,7 +30,7 @@ export class DirectCall implements DirectCallProperties, DirectCallMethods {
   }
 
   /** @internal **/
-  public static updateCustomItemsInPool(callId: string, customItems: Record<string, string>) {
+  public static updateCustomItems(callId: string, customItems: Record<string, string>) {
     const directCall = DirectCall.pool[callId];
     if (directCall) {
       directCall._updateCustomItems(customItems);

--- a/src/libs/DirectCall.ts
+++ b/src/libs/DirectCall.ts
@@ -29,6 +29,14 @@ export class DirectCall implements DirectCallProperties, DirectCallMethods {
     return directCall._updateInternal(props);
   }
 
+  /** @internal **/
+  public static updateCustomItemsInPool(callId: string, customItems: Record<string, string>) {
+    const directCall = DirectCall.pool[callId];
+    if (directCall) {
+      directCall._updateCustomItems(customItems);
+    }
+  }
+
   constructor(binder: NativeBinder, props: DirectCallProperties) {
     this._binder = binder;
     this._props = props;
@@ -54,7 +62,9 @@ export class DirectCall implements DirectCallProperties, DirectCallMethods {
     this._props = props;
     return this;
   }
-
+  private _updateCustomItems(customItems: Record<string, string>) {
+    this._props.customItems = customItems;
+  }
   public get ios_callUUID() {
     return this._props.ios_callUUID;
   }
@@ -400,5 +410,49 @@ export class DirectCall implements DirectCallProperties, DirectCallMethods {
    */
   public updateRemoteVideoView = (videoViewId: number) => {
     this._binder.nativeModule.updateRemoteVideoView(this.callId, videoViewId);
+  };
+
+  /**
+   * Updates custom items for this call.
+   *
+   * @param customItems Custom items of [String: String] to be updated or inserted.
+   * @returns Promise that resolves with CustomItemUpdateResult containing updated items and affected keys.
+   * @since 1.1.9
+   */
+  public updateCustomItems = async (customItems: Record<string, string>) => {
+    const result = await this._binder.nativeModule.directCallUpdateCustomItems(this.callId, customItems);
+    if (result && result.updatedItems) {
+      this._updateCustomItems(result.updatedItems);
+    }
+    return result;
+  };
+
+  /**
+   * Deletes custom items for this call.
+   *
+   * @param customItemKeys Custom item keys which you want to delete.
+   * @returns Promise that resolves with CustomItemUpdateResult containing updated items and affected keys.
+   * @since 1.1.9
+   */
+  public deleteCustomItems = async (customItemKeys: string[]) => {
+    const result = await this._binder.nativeModule.directCallDeleteCustomItems(this.callId, customItemKeys);
+    if (result && result.updatedItems) {
+      this._updateCustomItems(result.updatedItems);
+    }
+    return result;
+  };
+
+  /**
+   * Deletes all custom items for this call.
+   *
+   * @returns Promise that resolves with CustomItemUpdateResult containing updated items and affected keys.
+   * @since 1.1.9
+   */
+  public deleteAllCustomItems = async () => {
+    const result = await this._binder.nativeModule.directCallDeleteAllCustomItems(this.callId);
+    if (result && result.updatedItems) {
+      this._updateCustomItems(result.updatedItems);
+    }
+    return result;
   };
 }

--- a/src/libs/Room.ts
+++ b/src/libs/Room.ts
@@ -71,7 +71,9 @@ export class Room implements RoomProperties, GroupCallMethods {
     this._props = props;
     return this;
   }
-
+  private _updateCustomItems(customItems: Record<string, string>) {
+    this._props.customItems = customItems;
+  }
   public get roomId() {
     return this._props.roomId;
   }
@@ -233,5 +235,50 @@ export class Room implements RoomProperties, GroupCallMethods {
   public android_selectAudioDevice = async (device: AudioDevice) => {
     if (Platform.OS !== 'android') return;
     await this._binder.nativeModule.selectAudioDevice(ControllableModuleType.GROUP_CALL, this.roomId, device);
+  };
+
+  /**
+   * Updates custom items for this room.
+   * Custom items are key-value pairs that can be stored with the room.
+   *
+   * @param customItems - Key-value pairs to update
+   * @returns Promise resolving to the update result with updated items and affected keys
+   * @since 1.1.9
+   */
+  public updateCustomItems = async (customItems: Record<string, string>) => {
+    const result = await this._binder.nativeModule.groupCallUpdateCustomItems(this.roomId, customItems);
+    if (result && result.updatedItems) {
+      this._updateCustomItems(result.updatedItems);
+    }
+    return result;
+  };
+
+  /**
+   * Deletes custom items from this room.
+   *
+   * @param customItemKeys - Array of keys to delete
+   * @returns Promise resolving to the update result with updated items and affected keys
+   * @since 1.1.9
+   */
+  public deleteCustomItems = async (customItemKeys: string[]) => {
+    const result = await this._binder.nativeModule.groupCallDeleteCustomItems(this.roomId, customItemKeys);
+    if (result && result.updatedItems) {
+      this._updateCustomItems(result.updatedItems);
+    }
+    return result;
+  };
+
+  /**
+   * Deletes all custom items from this room.
+   *
+   * @returns Promise resolving to the update result with updated items and affected keys
+   * @since 1.1.9
+   */
+  public deleteAllCustomItems = async () => {
+    const result = await this._binder.nativeModule.groupCallDeleteAllCustomItems(this.roomId);
+    if (result && result.updatedItems) {
+      this._updateCustomItems(result.updatedItems);
+    }
+    return result;
   };
 }

--- a/src/libs/SendbirdCallsModule.tsx
+++ b/src/libs/SendbirdCallsModule.tsx
@@ -415,4 +415,43 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
     const queryKey = await this.binder.nativeModule.createRoomListQuery(params);
     return new RoomListQuery(queryKey, NativeQueryType.ROOM_LIST, this.binder);
   };
+
+  /**
+   * Updates custom items for a given call ID.
+   *
+   * @since 1.1.9
+   */
+  public updateCustomItems = async (callId: string, customItems: Record<string, string>) => {
+    const result = await this.binder.nativeModule.updateCustomItems(callId, customItems);
+    if (result && result.updatedItems) {
+      DirectCall.updateCustomItemsInPool(callId, result.updatedItems);
+    }
+    return result;
+  };
+
+  /**
+   * Deletes custom items for a given call ID.
+   *
+   * @since 1.1.9
+   */
+  public deleteCustomItems = async (callId: string, customItemKeys: string[]) => {
+    const result = await this.binder.nativeModule.deleteCustomItems(callId, customItemKeys);
+    if (result && result.updatedItems) {
+      DirectCall.updateCustomItemsInPool(callId, result.updatedItems);
+    }
+    return result;
+  };
+
+  /**
+   * Deletes all custom items for a given call ID.
+   *
+   * @since 1.1.9
+   */
+  public deleteAllCustomItems = async (callId: string) => {
+    const result = await this.binder.nativeModule.deleteAllCustomItems(callId);
+    if (result && result.updatedItems) {
+      DirectCall.updateCustomItemsInPool(callId, result.updatedItems);
+    }
+    return result;
+  };
 }

--- a/src/libs/SendbirdCallsModule.tsx
+++ b/src/libs/SendbirdCallsModule.tsx
@@ -424,7 +424,7 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
   public updateCustomItems = async (callId: string, customItems: Record<string, string>) => {
     const result = await this.binder.nativeModule.updateCustomItems(callId, customItems);
     if (result && result.updatedItems) {
-      DirectCall.updateCustomItemsInPool(callId, result.updatedItems);
+      DirectCall.updateCustomItems(callId, result.updatedItems);
     }
     return result;
   };
@@ -437,7 +437,7 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
   public deleteCustomItems = async (callId: string, customItemKeys: string[]) => {
     const result = await this.binder.nativeModule.deleteCustomItems(callId, customItemKeys);
     if (result && result.updatedItems) {
-      DirectCall.updateCustomItemsInPool(callId, result.updatedItems);
+      DirectCall.updateCustomItems(callId, result.updatedItems);
     }
     return result;
   };
@@ -450,7 +450,7 @@ export default class SendbirdCallsModule implements SendbirdCallsJavascriptSpec 
   public deleteAllCustomItems = async (callId: string) => {
     const result = await this.binder.nativeModule.deleteAllCustomItems(callId);
     if (result && result.updatedItems) {
-      DirectCall.updateCustomItemsInPool(callId, result.updatedItems);
+      DirectCall.updateCustomItems(callId, result.updatedItems);
     }
     return result;
   };

--- a/src/types/Call.ts
+++ b/src/types/Call.ts
@@ -334,7 +334,12 @@ export interface DirectCallProperties {
 }
 
 /** DirectCall */
-type JSDirectCallModule = AsJSDirectCall<NativeDirectCallModule>;
+type JSDirectCallModule = AsJSDirectCall<
+  Omit<
+    NativeDirectCallModule,
+    'directCallUpdateCustomItems' | 'directCallDeleteCustomItems' | 'directCallDeleteAllCustomItems'
+  >
+>;
 type JSDirectCallMediaDeviceControl = AsJSInterface<
   JSMediaDeviceControl,
   'android',
@@ -343,6 +348,9 @@ type JSDirectCallMediaDeviceControl = AsJSInterface<
 
 export interface DirectCallMethods extends JSDirectCallModule, JSDirectCallMediaDeviceControl {
   addListener(listener: Partial<DirectCallListener>): () => void;
+  updateCustomItems(customItems: Record<string, string>): Promise<CustomItemUpdateResult>;
+  deleteCustomItems(customItemKeys: string[]): Promise<CustomItemUpdateResult>;
+  deleteAllCustomItems(): Promise<CustomItemUpdateResult>;
 }
 
 export interface DirectCallLog {

--- a/src/types/NativeModule.ts
+++ b/src/types/NativeModule.ts
@@ -1,7 +1,13 @@
 import type { NativeModule, TurboModule } from 'react-native';
 
 import { BridgedQuery } from '../libs/BridgedQuery';
-import type { CallOptions, DirectCallLog, DirectCallProperties, SendbirdCallListener } from './Call';
+import type {
+  CallOptions,
+  CustomItemUpdateResult,
+  DirectCallLog,
+  DirectCallProperties,
+  SendbirdCallListener,
+} from './Call';
 import type { AudioDevice, VideoDevice } from './Media';
 import { SoundType } from './Media';
 import {
@@ -48,6 +54,10 @@ export interface NativeCommonModule {
   fetchRoomById(roomId: string): Promise<RoomProperties>;
   getCachedRoomById(roomId: string): Promise<RoomProperties | null>;
 
+  updateCustomItems(callId: string, customItems: Record<string, string>): Promise<CustomItemUpdateResult>;
+  deleteCustomItems(callId: string, customItemKeys: string[]): Promise<CustomItemUpdateResult>;
+  deleteAllCustomItems(callId: string): Promise<CustomItemUpdateResult>;
+
   /** @platform Android **/
   handleFirebaseMessageData(data: Record<string, string>): void;
 
@@ -93,15 +103,16 @@ export interface NativeDirectCallModule {
   updateLocalVideoView(callId: string, videoViewId: number): void;
   updateRemoteVideoView(callId: string, videoViewId: number): void;
 
+  directCallUpdateCustomItems(callId: string, customItems: Record<string, string>): Promise<CustomItemUpdateResult>;
+  directCallDeleteCustomItems(callId: string, customItemKeys: string[]): Promise<CustomItemUpdateResult>;
+  directCallDeleteAllCustomItems(callId: string): Promise<CustomItemUpdateResult>;
+
   /** Not implemented yet belows **/
   // hold(callId:string): Promise<void>;
   // unhold(callId:string, force: boolean): Promise<void>;
   //
   // captureLocalVideoView(callId:string): Promise<string>; // capture -> tmp file path
   // captureRemoteVideoView(callId:string): Promise<string>;
-  // updateCustomItems(callId:string, items: Record<string, string>): Promise<CustomItemUpdateResult>;
-  // deleteAllCustomItems(callId:string): Promise<void>;
-  // deleteCustomItems(callId:string, key: string[]): Promise<CustomItemUpdateResult>;
   //
   // startRecording(callId:string, options: RecordingOptions): Promise<{ recordingId: string }>;
   // stopRecording(callId:string, recordingId: string): void;
@@ -113,6 +124,10 @@ export interface NativeDirectCallModule {
 export interface NativeGroupCallModule {
   enter(roomId: string, options: EnterParams): Promise<void>;
   exit(roomId: string): void;
+
+  groupCallUpdateCustomItems(roomId: string, customItems: Record<string, string>): Promise<CustomItemUpdateResult>;
+  groupCallDeleteCustomItems(roomId: string, customItemKeys: string[]): Promise<CustomItemUpdateResult>;
+  groupCallDeleteAllCustomItems(roomId: string): Promise<CustomItemUpdateResult>;
 }
 
 export interface NativeQueries {

--- a/src/types/Room.ts
+++ b/src/types/Room.ts
@@ -4,7 +4,7 @@ import type { AudioDevice, AudioDeviceChangedInfo } from './Media';
 import type { NativeGroupCallModule } from './NativeModule';
 import { JSMediaDeviceControl } from './NativeModule';
 import type { ParticipantProperties } from './Participant';
-import type { AsJSGroupCall, AsJSInterface } from './index';
+import type { AsJSGroupCall, AsJSInterface, CustomItemUpdateResult } from './index';
 
 export interface RoomListener {
   /**
@@ -185,7 +185,12 @@ export interface RoomProperties {
   createdBy: string;
 }
 
-type JSGroupCallModule = AsJSGroupCall<NativeGroupCallModule>;
+type JSGroupCallModule = AsJSGroupCall<
+  Omit<
+    NativeGroupCallModule,
+    'groupCallUpdateCustomItems' | 'groupCallDeleteCustomItems' | 'groupCallDeleteAllCustomItems'
+  >
+>;
 type JSGroupCallMediaDeviceControl = AsJSInterface<
   Pick<JSMediaDeviceControl, 'selectAudioDevice'>,
   'android',
@@ -194,6 +199,9 @@ type JSGroupCallMediaDeviceControl = AsJSInterface<
 
 export interface GroupCallMethods extends JSGroupCallModule, JSGroupCallMediaDeviceControl {
   addListener(listener: Partial<RoomListener>): () => void;
+  updateCustomItems(customItems: Record<string, string>): Promise<CustomItemUpdateResult>;
+  deleteCustomItems(customItemKeys: string[]): Promise<CustomItemUpdateResult>;
+  deleteAllCustomItems(): Promise<CustomItemUpdateResult>;
 }
 
 export type RoomParams = {


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[[CLNP-7606]](https://sendbird.atlassian.net/browse/CLNP-7606)

## Description Of Changes

SendbirdCallsModule, DirectCall, Room 에 updateCustomItems, deleteCustomItems, deleteAllCustomItems 를 추가하였습니다.
room 의 deleteAllCustomItems 의 경우 Android calls 에서 해당 API를 지원하지 않아 deleteCustomItems 를 사용하도록 예외 처리 하였습니다.

추가로[ Android 16kb 지원](https://community.sendbird.com/t/reactnative-android-16kb-page-size-issue/11213)을 위해 calls 버전을 변경하였습니다.

iOS, Andorid 디바이스에서 테스트 완료 하였습니다.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply\_

- [ ] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-7606]: https://sendbird.atlassian.net/browse/CLNP-7606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ