### PR TITLE
chore: migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Validate permissions and branch
         uses: actions/github-script@v7

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,6 +20,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Validate permissions and branch
         uses: actions/github-script@v7
@@ -102,17 +105,13 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        with:
+          node-version: '24'
 
       - name: Configure Git
         run: |
           git config --global user.email "sha.sdk_deployment@sendbird.com"
           git config --global user.name "sendbird-sdk-deployment"
-
-      - name: Configure NPM
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
 
       - name: Build package
         run: yarn build


### PR DESCRIPTION
## Summary
- Remove NPM_TOKEN secret and .npmrc auth setup
- Add OIDC permissions (id-token: write) for trusted publishing
- Bump Node.js to 24 via setup action override (npm 11+ required for OIDC)

## Note
npm package settings에서 GitHub Actions OIDC trusted publisher 연동 필요:
- Workflow: `publish-package.yml`